### PR TITLE
Add project sort

### DIFF
--- a/src/app/api/getProjectList.ts
+++ b/src/app/api/getProjectList.ts
@@ -7,7 +7,9 @@ import { LOGIN_PAGE_PATH } from "@/constant";
 
 export const getProjectList = async (
   offset: number,
-  max: number
+  max: number,
+  sort: "created" | "name",
+  order: "asc" | "desc"
 ): Promise<ProjectType> => {
   const token = cookies().get("token")?.value;
   const shortTermToken = cookies().get("shortTermToken")?.value;
@@ -18,7 +20,12 @@ export const getProjectList = async (
     new URL(
       `${
         process.env.NEXT_PUBLIC_API_BASE_URL
-      }/api${projectUrl.getProjectListUrl(offset.toString(), max.toString())}`,
+      }/api${projectUrl.getProjectListUrl(
+        offset.toString(),
+        max.toString(),
+        sort,
+        order
+      )}`,
       process.env.NEXT_PUBLIC_API_BASE_URL
     ),
     {

--- a/src/app/api/getProjectList.ts
+++ b/src/app/api/getProjectList.ts
@@ -2,14 +2,14 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { projectUrl } from "@/libs";
-import type { ProjectType } from "@/types";
+import type { ProjectType, sortType, orderType } from "@/types";
 import { LOGIN_PAGE_PATH } from "@/constant";
 
 export const getProjectList = async (
   offset: number,
   max: number,
-  sort: "created" | "name",
-  order: "asc" | "desc"
+  sort: sortType,
+  order: orderType
 ): Promise<ProjectType> => {
   const token = cookies().get("token")?.value;
   const shortTermToken = cookies().get("shortTermToken")?.value;

--- a/src/app/project/page.tsx
+++ b/src/app/project/page.tsx
@@ -3,8 +3,8 @@ import { redirect } from "next/navigation";
 
 import { ProjectPage } from "@/pageContainer";
 import { LOGIN_PAGE_PATH } from "@/constant";
-
 import { getProjectList } from "@/app/api";
+import { sortType, orderType } from "@/types";
 
 interface Params {
   searchParams?: { [key: string]: string | string[] | undefined };
@@ -21,14 +21,14 @@ const Project: React.FC<Params> = async ({ searchParams }) => {
   const max = typeof maxParam === "string" ? parseInt(maxParam) : 10;
 
   const sortParam = searchParams?.sort;
-  const sort = (typeof offsetParam === "string" ? sortParam : "created") as
-    | "name"
-    | "created";
+  const sort = (
+    typeof offsetParam === "string" ? sortParam : "created"
+  ) as sortType;
 
   const orderParam = searchParams?.order;
-  const order = (typeof orderParam === "string" ? orderParam : "desc") as
-    | "asc"
-    | "desc";
+  const order = (
+    typeof orderParam === "string" ? orderParam : "desc"
+  ) as orderType;
 
   const projectList = await getProjectList(offset, max, sort, order);
 

--- a/src/app/project/page.tsx
+++ b/src/app/project/page.tsx
@@ -19,13 +19,30 @@ const Project: React.FC<Params> = async ({ searchParams }) => {
 
   const maxParam = searchParams?.max;
   const max = typeof maxParam === "string" ? parseInt(maxParam) : 10;
-  console.log(offsetParam, maxParam);
 
-  const projectList = await getProjectList(offset, max);
+  const sortParam = searchParams?.sort;
+  const sort = (typeof offsetParam === "string" ? sortParam : "created") as
+    | "name"
+    | "created";
+
+  const orderParam = searchParams?.order;
+  const order = (typeof orderParam === "string" ? orderParam : "desc") as
+    | "asc"
+    | "desc";
+
+  const projectList = await getProjectList(offset, max, sort, order);
 
   if (!token && !shortTermToken) redirect(LOGIN_PAGE_PATH);
 
-  return <ProjectPage initialData={projectList} offset={offset} max={max} />;
+  return (
+    <ProjectPage
+      initialData={projectList}
+      offset={offset}
+      max={max}
+      order={order}
+      sort={sort}
+    />
+  );
 };
 
 export default Project;

--- a/src/hooks/api/useGetProjectList.ts
+++ b/src/hooks/api/useGetProjectList.ts
@@ -9,13 +9,17 @@ import type { UseQueryOptions } from "@tanstack/react-query";
 export const useGetProjectList = (
   max: number,
   offset: number,
+  sort: "created" | "name",
+  order: "asc" | "desc",
   initialData?: ProjectType,
   options?: Omit<UseQueryOptions<ProjectType>, "queryKey">
 ) =>
   useQuery({
     queryKey: projectQueryKeys.getProjectListKey(
       offset.toString(),
-      max.toString()
+      max.toString(),
+      sort,
+      order
     ),
     queryFn: () =>
       get<ProjectType>(

--- a/src/hooks/api/useGetProjectList.ts
+++ b/src/hooks/api/useGetProjectList.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { get, projectQueryKeys, projectUrl } from "@/libs";
-import type { ProjectType } from "@/types";
+import type { ProjectType, sortType, orderType } from "@/types";
 import { minutesToMs } from "@/utils";
 
 import type { UseQueryOptions } from "@tanstack/react-query";
@@ -9,8 +9,8 @@ import type { UseQueryOptions } from "@tanstack/react-query";
 export const useGetProjectList = (
   max: number,
   offset: number,
-  sort: "created" | "name",
-  order: "asc" | "desc",
+  sort: sortType,
+  order: orderType,
   initialData?: ProjectType,
   options?: Omit<UseQueryOptions<ProjectType>, "queryKey">
 ) =>

--- a/src/libs/api/queryKeys.ts
+++ b/src/libs/api/queryKeys.ts
@@ -6,8 +6,8 @@ export const projectQueryKeys = {
   getProjectListKey: (
     offset?: string,
     max?: string,
-    sort?: string,
-    order?: string
+    sort?: "created" | "name",
+    order?: "asc" | "desc"
   ) => ["project", "list", offset, max, sort, order],
   postProject: () => ["project", "create"],
 };

--- a/src/libs/api/queryKeys.ts
+++ b/src/libs/api/queryKeys.ts
@@ -1,3 +1,5 @@
+import { sortType, orderType } from "@/types";
+
 export const authQueryKeys = {
   loginKey: () => ["login"],
 };
@@ -6,8 +8,8 @@ export const projectQueryKeys = {
   getProjectListKey: (
     offset?: string,
     max?: string,
-    sort?: "created" | "name",
-    order?: "asc" | "desc"
+    sort?: sortType,
+    order?: orderType
   ) => ["project", "list", offset, max, sort, order],
   postProject: () => ["project", "create"],
 };

--- a/src/libs/api/requestUrlController.ts
+++ b/src/libs/api/requestUrlController.ts
@@ -1,3 +1,5 @@
+import { sortType, orderType } from "@/types";
+
 export const authUrl = {
   loginUrl: () => "/authenticate",
 };
@@ -7,8 +9,8 @@ export const projectUrl = {
   getProjectListUrl: (
     offset?: string,
     max?: string,
-    sort?: "created" | "name",
-    order?: "asc" | "desc"
+    sort?: sortType,
+    order?: orderType
   ) =>
     `/project.json?offset=${parseInt(offset ?? "0") * 10}&max=${
       max ?? "10"

--- a/src/libs/api/requestUrlController.ts
+++ b/src/libs/api/requestUrlController.ts
@@ -7,8 +7,10 @@ export const projectUrl = {
   getProjectListUrl: (
     offset?: string,
     max?: string,
-    sort?: string,
-    order?: string
+    sort?: "created" | "name",
+    order?: "asc" | "desc"
   ) =>
-    `/project.json?offset=${parseInt(offset ?? "0") * 10}&max=${max ?? "10"}`,
+    `/project.json?offset=${parseInt(offset ?? "0") * 10}&max=${
+      max ?? "10"
+    }&sort=${sort ?? "created"}&order=${order ?? "desc"}`,
 };

--- a/src/pageContainer/DetailPage.tsx
+++ b/src/pageContainer/DetailPage.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 const DetailPage: React.FC<Props> = ({ projectId }) => {
-  const { data: projectList } = useGetProjectList(0, 1000);
+  const { data: projectList } = useGetProjectList(0, 1000, "created", "desc");
   const [filteredProject, setProjectIndex] = useState<
     CollectionType | undefined
   >();

--- a/src/pageContainer/ProjectPage.tsx
+++ b/src/pageContainer/ProjectPage.tsx
@@ -2,7 +2,7 @@
 
 import { useGetProjectList } from "@/hooks";
 import { ProjectCard, PaginationController } from "@/components";
-import { ProjectType } from "@/types";
+import { ProjectType, sortType, orderType } from "@/types";
 
 import { useEffect, useState } from "react";
 import { PROJECT_PAGE_PATH } from "@/constant";
@@ -12,8 +12,8 @@ interface Props {
   initialData: ProjectType;
   offset: number;
   max: number;
-  sort: "created" | "name";
-  order: "asc" | "desc";
+  sort: sortType;
+  order: orderType;
 }
 
 const ProjectPage: React.FC<Props> = ({
@@ -32,8 +32,8 @@ const ProjectPage: React.FC<Props> = ({
   );
 
   const [totalPages, setTotalPages] = useState<number>(0);
-  const [order, setOrder] = useState<"desc" | "asc">(initialOrder);
-  const [sort, setSort] = useState<"created" | "name">(initialSort);
+  const [order, setOrder] = useState<orderType>(initialOrder);
+  const [sort, setSort] = useState<sortType>(initialSort);
 
   const { push } = useRouter();
 
@@ -72,7 +72,7 @@ const ProjectPage: React.FC<Props> = ({
         )}
         <select
           value={sort}
-          onChange={(e) => setSort(e.target.value as "created" | "name")}
+          onChange={(e) => setSort(e.target.value as sortType)}
           className="cursor-pointer text-gray-500"
         >
           <option value="created">created</option>
@@ -80,7 +80,7 @@ const ProjectPage: React.FC<Props> = ({
         </select>
         <select
           value={order}
-          onChange={(e) => setOrder(e.target.value as "asc" | "desc")}
+          onChange={(e) => setOrder(e.target.value as orderType)}
           className="cursor-pointer text-gray-500"
         >
           <option value="asc">오름차순</option>

--- a/src/pageContainer/ProjectPage.tsx
+++ b/src/pageContainer/ProjectPage.tsx
@@ -12,12 +12,28 @@ interface Props {
   initialData: ProjectType;
   offset: number;
   max: number;
+  sort: "created" | "name";
+  order: "asc" | "desc";
 }
 
-const ProjectPage: React.FC<Props> = ({ initialData, offset, max }) => {
-  const { data: projectList } = useGetProjectList(max, offset, initialData);
+const ProjectPage: React.FC<Props> = ({
+  initialData,
+  offset,
+  max,
+  sort: initialSort,
+  order: initialOrder,
+}) => {
+  const { data: projectList } = useGetProjectList(
+    max,
+    offset,
+    initialSort,
+    initialOrder,
+    initialData
+  );
 
   const [totalPages, setTotalPages] = useState<number>(0);
+  const [order, setOrder] = useState<"desc" | "asc">(initialOrder);
+  const [sort, setSort] = useState<"created" | "name">(initialSort);
 
   const { push } = useRouter();
 
@@ -26,7 +42,13 @@ const ProjectPage: React.FC<Props> = ({ initialData, offset, max }) => {
   }, [projectList]);
 
   const paginate = (max: number) =>
-    push(`${PROJECT_PAGE_PATH}?offset=${offset}&max=${max}`);
+    push(
+      `${PROJECT_PAGE_PATH}?offset=${offset}&max=${max}&order=${order}&sort=${sort}`
+    );
+
+  useEffect(() => {
+    paginate(max);
+  }, [order, sort]);
 
   return (
     <div className="bg-white p-8 rounded shadow-md w-80">
@@ -48,11 +70,27 @@ const ProjectPage: React.FC<Props> = ({ initialData, offset, max }) => {
             currentMax={max}
           />
         )}
+        <select
+          value={sort}
+          onChange={(e) => setSort(e.target.value as "created" | "name")}
+          className="cursor-pointer text-gray-500"
+        >
+          <option value="created">created</option>
+          <option value="name">name</option>
+        </select>
+        <select
+          value={order}
+          onChange={(e) => setOrder(e.target.value as "asc" | "desc")}
+          className="cursor-pointer text-gray-500"
+        >
+          <option value="asc">오름차순</option>
+          <option value="desc">내림차순</option>
+        </select>
         <button
           className="cursor-pointer text-gray-500"
           onClick={() => push(`${PROJECT_PAGE_PATH}/create`)}
         >
-          프로젝트 추가{" "}
+          프로젝트 추가
         </button>
       </section>
       <section>

--- a/src/types/projectType.ts
+++ b/src/types/projectType.ts
@@ -38,3 +38,6 @@ export interface ProjectRequestType {
   name: string;
   ontologyId: number;
 }
+
+export type orderType = "asc" | "desc";
+export type sortType = "created" | "name";


### PR DESCRIPTION
## 개요 💡

> 프로젝트를 정렬할 수 있도록 만들었습니다.

## 작업내용 ⌨️

- 기존 프로젝트 리스트 API의 query key와 타입들을 수정했습니다.
- 추후 컬럼 추가 시 확장성을 고려했습니다.

## 관련 issue 🤯

- 시간 이슈로 일단 확장 가능한 설계로 제작 이후 추후에 보강하겠습니다.
